### PR TITLE
使用「设备特定选项」时的警告

### DIFF
--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -54,7 +54,7 @@
   "overloadLineHeightPxDesc": "Must check the above switch to take effect, default: 28 unit: px",
 
   "addCurrentDeviceIntoListLabel":"Add",
-  "addCurrentDeviceIntoListDesc":"",
+  "addCurrentDeviceIntoListDesc":"When you click the button, the interface will be reloaded, and unsaved configurations will be lost, so please save other configuration items before clicking the button",
   "addCurrentDeviceIntoList":"Add current device into the list",
   "enableDeviceListDesc":"This list is used to control which device should enable this plugin on, please try not to modify it manually",
   "enableDeviceList":"Enable Device List",
@@ -63,7 +63,7 @@
   "hintDeviceSpecificSettingsTitle":"<hr style='border: none; border-top: 3px solid;'>● Devices Specific Options",
   "onlyEnableListedDevices":"Only Enable on Listed Devices",
   "removeCurrentDeviceFromList":"Remove current device from the list",
-  "removeCurrentDeviceFromListDesc":"",
+  "removeCurrentDeviceFromListDesc":"When you click the button, the interface will be reloaded, and unsaved configurations will be lost, so please save other configuration items before clicking the button",
   "removeCurrentDeviceFromListLabel":"Remove",
  
   "hideContextualLabel": "Hide Contextual Label",

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -46,7 +46,7 @@
   "overloadLineHeightPxDesc": "必须勾选上面的开关才能生效，默认值：28 单位：像素",
 
   "addCurrentDeviceIntoListLabel": "添加",
-  "addCurrentDeviceIntoListDesc": "",
+  "addCurrentDeviceIntoListDesc": "点击按钮时将重新加载界面，没有保存的配置将丢失，所以请在保存好其他配置项之后再点击按钮",
   "addCurrentDeviceIntoList": "将当前设备添加到列表中",
   "enableDeviceListDesc": "此列表用于控制该插件在哪些设备上启用，请尽量不要手动修改",
   "enableDeviceList": "启用的设备列表",
@@ -55,7 +55,7 @@
   "hintDeviceSpecificSettingsTitle": "<hr style='border: none; border-top: 3px solid;'>● 设备特定选项",
   "onlyEnableListedDevices": "仅在列表中的设备上启用",
   "removeCurrentDeviceFromList": "从列表中移除当前设备",
-  "removeCurrentDeviceFromListDesc": "",
+  "removeCurrentDeviceFromListDesc": "点击按钮时将重新加载界面，没有保存的配置将丢失，所以请在保存好其他配置项之后再点击按钮",
   "removeCurrentDeviceFromListLabel": "移除",
   "hideContextualLabel": "隐藏文档详情标签",
   "hideContextualLabelDesc": "隐藏文档树中当前文档的悬停标签（创建时间等弹出式标签）",


### PR DESCRIPTION
增加了一段话：

- 点击按钮时将重新加载界面，没有保存的配置将丢失，所以请在保存好其他配置项之后再点击按钮
- When you click the button, the interface will be reloaded, and unsaved configurations will be lost, so please save other configuration items before clicking the button

关联：#7